### PR TITLE
More compatible license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,22 @@
-Copyright © 2022 by Polyfrost and Wyvest
+MIT License
 
-All rights reserved.
+Copyright (c) 2021 DJtheRedstoner
+Copyright (c) 2022 Polyfrost and Wyvest
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Afaik you can't take MonkeyBlur and change the license. There is a license for MonkeyBlur included in the resources, but this only applies to the class files.

It probably could be possible to keep ARR (since MIT is less strict than GPL), but you'd probably have to annotate the parts from MonkeyBlur with comments.